### PR TITLE
Finish updating Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To install the fonts manually you may use either the [OTF][otf_latest] or [TTF][
 
 Most Linux and BSD systems can handle either [TTF][ttf_latest] or [OTF][otf_latest] format fonts. We are aware of package manager support on the following distros:
 
-* *Arch Linux*: install either [ttf-hack](https://aur.archlinux.org/packages/ttf-hack) or [otf-hack](https://aur.archlinux.org/packages/otf-hack) from the AUR manually or using the AUR helper of your choice:
+* *Arch Linux*: install the [ttf-hack](https://www.archlinux.org/packages/community/any/ttf-hack/) package from the community repository ([otf-hack](https://aur.archlinux.org/packages/otf-hack/) is available in the AUR):
 
         $ pacman -S ttf-hack
 


### PR DESCRIPTION
Somebody on the previous PR mentioned that the ttf-hack package moved
from the AUR to the community repository. See:

https://github.com/chrissimpkins/Hack/pull/151#discussion_r48590088

This was correct information and the change in 3e47153 to a different
package manager is also correct, but the package URL and the description
also needs to match. Installing community package cannot be done
"manually" nor does mentioning an "AUR helper" make sense any more.  If
the official core package manager is involved (yeh!) then just let it do
its job.