### PR TITLE
Do not recommend fc-cache -s in INSTALLATION.md

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -58,7 +58,7 @@ If no packages exist in your package manager, download the [TTF archive][ttf_lat
 **Clear and Regenerate Font Cache**: Following a manual install on Linux, systems using Fontconfig may need to regenerate the font caches and indexes:
 
 ```
-$ fc-cache -s
+$ fc-cache
 $ mkfontscale <install_path>
 $ mkfontdir <install_path>
 ```


### PR DESCRIPTION
`fc-cache -s` will only scan system-wide font directories, omitting user dirs.
(The line above points out that fonts can be put in a local directory, so this option doesn't make sense)